### PR TITLE
Add support for new driver discovery mechanism.

### DIFF
--- a/intake_odbc/__init__.py
+++ b/intake_odbc/__init__.py
@@ -3,4 +3,6 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
+import intake  # Import this first to avoid circular imports during discovery.
+del intake
 from .intake_odbc import ODBCPartitionedSource, ODBCSource

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ setup(
     license='BSD',
     py_modules=['intake_odbc'],
     packages=['intake_odbc'],
+    entry_points={
+        'intake.drivers': [
+	    'odbc = intake_odbc.intake_odbc:ODBCPartitionedSource',
+	]},
     package_data={'': ['*.csv', '*.yml', '*.html']},
     include_package_data=True,
     install_requires=requires,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,11 @@
+import intake
+import pytest
+
+
+def test_discovery():
+    with pytest.warns(None) as record:
+        registry = intake.autodiscover()
+    # For awhile we expect a PendingDeprecationWarning due to
+    # do_pacakge_scan=True. But we should *not* get a FutureWarning.
+    for record in record.list:
+        assert not isinstance(record.message, FutureWarning)


### PR DESCRIPTION
See intake/intake#236.

@martindurant Should we expose `ODBCSource` or `ODBCPartitionedSource` here?
They (reasonably) have the same name, but only one can be discoverable by
default. The original discovery code would have found the first one defined.